### PR TITLE
Add option to switch between token highlighting mode and markdown output mode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,19 +15,28 @@ cp -r public/* dist/
 
 # Replace API key placeholder in index.html
 if [ -z "$OPENROUTER_API_KEY" ]; then
-    echo "❌ Error: OPENROUTER_API_KEY environment variable is not set"
-    exit 1
-fi
-
-echo "🔑 Injecting API key into build..."
-
-# Replace the placeholder with the actual API key
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # macOS
-    sed -i '' "s/%API_KEY%/$OPENROUTER_API_KEY/g" dist/index.html
+    echo "⚠️  OPENROUTER_API_KEY environment variable is not set"
+    echo "🔧 Building for local development (API key input will be required)"
+    
+    # For local development, keep the placeholder so the app will show API key input
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS - replace with a clear development placeholder
+        sed -i '' "s/%API_KEY%/DEVELOPMENT_MODE_NO_KEY/g" dist/index.html
+    else
+        # Linux
+        sed -i "s/%API_KEY%/DEVELOPMENT_MODE_NO_KEY/g" dist/index.html
+    fi
 else
-    # Linux
-    sed -i "s/%API_KEY%/$OPENROUTER_API_KEY/g" dist/index.html
+    echo "🔑 Injecting API key into build..."
+    
+    # Replace the placeholder with the actual API key
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS
+        sed -i '' "s/%API_KEY%/$OPENROUTER_API_KEY/g" dist/index.html
+    else
+        # Linux
+        sed -i "s/%API_KEY%/$OPENROUTER_API_KEY/g" dist/index.html
+    fi
 fi
 
 # Process build info if available
@@ -61,22 +70,22 @@ if [ -f "build-data/buildinfo.yml" ]; then
         sed -i "s|%BUILD_TIMESTAMP_ISO%|${TIMESTAMP_ISO}|g" dist/index.html
     fi
 else
-    echo "⚠️  No build info found, using fallback values..."
-    # Replace with fallback values for local development
+    echo "⚠️  No build info found, running in local development mode..."
+    # Replace with development-friendly values
     CURRENT_TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
     CURRENT_TIMESTAMP_ISO=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
     
     if [[ "$OSTYPE" == "darwin"* ]]; then
         # macOS
-        sed -i '' "s|%BUILD_COMMIT%|local-dev|g" dist/index.html
-        sed -i '' "s|%BUILD_ID%|local|g" dist/index.html
+        sed -i '' "s|%BUILD_COMMIT%|Development|g" dist/index.html
+        sed -i '' "s|%BUILD_ID%|Local Dev|g" dist/index.html
         sed -i '' "s|%BUILD_URL%|#|g" dist/index.html
         sed -i '' "s|%BUILD_TIMESTAMP%|${CURRENT_TIMESTAMP}|g" dist/index.html
         sed -i '' "s|%BUILD_TIMESTAMP_ISO%|${CURRENT_TIMESTAMP_ISO}|g" dist/index.html
     else
         # Linux
-        sed -i "s|%BUILD_COMMIT%|local-dev|g" dist/index.html
-        sed -i "s|%BUILD_ID%|local|g" dist/index.html
+        sed -i "s|%BUILD_COMMIT%|Development|g" dist/index.html
+        sed -i "s|%BUILD_ID%|Local Dev|g" dist/index.html
         sed -i "s|%BUILD_URL%|#|g" dist/index.html
         sed -i "s|%BUILD_TIMESTAMP%|${CURRENT_TIMESTAMP}|g" dist/index.html
         sed -i "s|%BUILD_TIMESTAMP_ISO%|${CURRENT_TIMESTAMP_ISO}|g" dist/index.html

--- a/public/index.html
+++ b/public/index.html
@@ -77,6 +77,20 @@
                     </div>
                 </div>
                 
+                <div class="output-mode-control">
+                    <div class="output-mode-label">Output Mode</div>
+                    <div class="output-mode-toggle">
+                        <div class="toggle-container">
+                            <input type="checkbox" id="outputModeToggle" class="toggle-checkbox">
+                            <label for="outputModeToggle" class="toggle-label">
+                                <span class="toggle-slider"></span>
+                                <span class="toggle-text-left">Confidence</span>
+                                <span class="toggle-text-right">Markdown</span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                
                 <div class="footer-placeholder">
                     <p>Copyright &copy; 2025 Edward Jensen. See on GitHub: <a href="https://github.com/edwardjensen/ai-confidence-demo" target="_blank">edwardjensen/ai-confidence-demo</a>.</p>
                     <div class="build-info">

--- a/public/script.js
+++ b/public/script.js
@@ -74,8 +74,13 @@ function initializeApp() {
         isProduction = true;
         apiKey = window.AI_DEMO_CONFIG.apiKey;
         
-        if (!apiKey || apiKey === '%API_KEY%') {
-            showError('Production environment not properly configured. Please contact the administrator.');
+        if (!apiKey || apiKey === '%API_KEY%' || apiKey === 'DEVELOPMENT_MODE_NO_KEY') {
+            if (apiKey === 'DEVELOPMENT_MODE_NO_KEY') {
+                // Local development mode - show API key input
+                showLocalDevMode();
+            } else {
+                showError('Production environment not properly configured. Please contact the administrator.');
+            }
             return;
         }
         
@@ -491,3 +496,24 @@ document.addEventListener('DOMContentLoaded', function() {
     // Format timestamp when page loads
     formatBuildTimestamp();
 });
+
+function showLocalDevMode() {
+    // Show API key input for local development
+    const apiKeyContainer = document.getElementById('apiKeyContainer');
+    if (apiKeyContainer) {
+        apiKeyContainer.style.display = 'block';
+    }
+    
+    const chatContainer = document.getElementById('chatContainer');
+    if (chatContainer) {
+        chatContainer.style.display = 'none';
+    }
+    
+    // Update production notice to show development mode
+    const productionNotice = document.querySelector('.production-notice p');
+    if (productionNotice) {
+        productionNotice.innerHTML = '🔧 Development Mode: Please enter your API key to continue.';
+        productionNotice.parentElement.style.backgroundColor = '#fff3cd';
+        productionNotice.parentElement.style.borderColor = '#ffeaa7';
+    }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -629,7 +629,10 @@ div.main-layout div.sidebar div.sidebar-bottom {
 
 .toggle-container {
     position: relative;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 1rem;
+    min-width: 200px;
 }
 
 .toggle-checkbox {
@@ -642,10 +645,11 @@ div.main-layout div.sidebar div.sidebar-bottom {
 .toggle-label {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     cursor: pointer;
     user-select: none;
     position: relative;
-    padding: 0 4rem;
+    width: 100%;
 }
 
 .toggle-slider {
@@ -658,6 +662,7 @@ div.main-layout div.sidebar div.sidebar-bottom {
     background-color: #007aff;
     border-radius: 0.75rem;
     transition: background-color 0.3s;
+    z-index: 1;
 }
 
 .toggle-slider::before {
@@ -683,19 +688,12 @@ div.main-layout div.sidebar div.sidebar-bottom {
 
 .toggle-text-left,
 .toggle-text-right {
-    position: absolute;
     font-size: 0.8rem;
     font-weight: 500;
     color: #666;
     transition: color 0.3s;
-}
-
-.toggle-text-left {
-    left: 0;
-}
-
-.toggle-text-right {
-    right: 0;
+    z-index: 2;
+    position: relative;
 }
 
 .toggle-checkbox:not(:checked) + .toggle-label .toggle-text-left {

--- a/public/styles.css
+++ b/public/styles.css
@@ -607,6 +607,195 @@ div.main-layout div.sidebar div.sidebar-bottom {
     font-size: 0.7rem;
 }
 
+/* Output Mode Toggle Styles */
+.output-mode-control {
+    padding: 1rem;
+    background: #f8f9fa;
+    border-bottom: 1px solid #e5e5e7;
+}
+
+.output-mode-label {
+    text-align: center;
+    margin-bottom: 0.75rem;
+    font-size: 0.9rem;
+    color: #333;
+    font-weight: 500;
+}
+
+.output-mode-toggle {
+    display: flex;
+    justify-content: center;
+}
+
+.toggle-container {
+    position: relative;
+    display: inline-block;
+}
+
+.toggle-checkbox {
+    opacity: 0;
+    position: absolute;
+    width: 0;
+    height: 0;
+}
+
+.toggle-label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+    padding: 0 4rem;
+}
+
+.toggle-slider {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 3rem;
+    height: 1.5rem;
+    background-color: #007aff;
+    border-radius: 0.75rem;
+    transition: background-color 0.3s;
+}
+
+.toggle-slider::before {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 1.25rem;
+    height: 1.25rem;
+    background-color: white;
+    border-radius: 50%;
+    transition: transform 0.3s;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.toggle-checkbox:checked + .toggle-label .toggle-slider {
+    background-color: #10a37f;
+}
+
+.toggle-checkbox:checked + .toggle-label .toggle-slider::before {
+    transform: translateX(1.5rem);
+}
+
+.toggle-text-left,
+.toggle-text-right {
+    position: absolute;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: #666;
+    transition: color 0.3s;
+}
+
+.toggle-text-left {
+    left: 0;
+}
+
+.toggle-text-right {
+    right: 0;
+}
+
+.toggle-checkbox:not(:checked) + .toggle-label .toggle-text-left {
+    color: #007aff;
+    font-weight: 600;
+}
+
+.toggle-checkbox:checked + .toggle-label .toggle-text-right {
+    color: #10a37f;
+    font-weight: 600;
+}
+
+/* Markdown Styling */
+.markdown-content {
+    line-height: 1.6;
+    color: #1a1a1a;
+}
+
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
+.markdown-content h6 {
+    margin: 1rem 0 0.5rem 0;
+    font-weight: 600;
+    color: #1a1a1a;
+}
+
+.markdown-content h1 { font-size: 1.5rem; }
+.markdown-content h2 { font-size: 1.3rem; }
+.markdown-content h3 { font-size: 1.1rem; }
+
+.markdown-content p {
+    margin: 0.5rem 0;
+}
+
+.markdown-content strong {
+    font-weight: 600;
+}
+
+.markdown-content em {
+    font-style: italic;
+}
+
+.markdown-content code {
+    background: #f3f4f6;
+    padding: 0.125rem 0.25rem;
+    border-radius: 0.25rem;
+    font-family: 'SFMono-Regular', 'Monaco', 'Consolas', monospace;
+    font-size: 0.9em;
+    color: #d63384;
+}
+
+.markdown-content pre {
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    margin: 1rem 0;
+    overflow-x: auto;
+    font-family: 'SFMono-Regular', 'Monaco', 'Consolas', monospace;
+    font-size: 0.875rem;
+    line-height: 1.4;
+}
+
+.markdown-content pre code {
+    background: none;
+    padding: 0;
+    border-radius: 0;
+    color: inherit;
+}
+
+.markdown-content ul,
+.markdown-content ol {
+    margin: 0.5rem 0;
+    padding-left: 1.5rem;
+}
+
+.markdown-content li {
+    margin: 0.25rem 0;
+}
+
+.markdown-content blockquote {
+    border-left: 4px solid #007aff;
+    margin: 1rem 0;
+    padding-left: 1rem;
+    color: #6b7280;
+    font-style: italic;
+}
+
+.markdown-content a {
+    color: #007aff;
+    text-decoration: none;
+}
+
+.markdown-content a:hover {
+    text-decoration: underline;
+}
+
 /* Responsive design for mobile */
 @media (max-width: 768px) {
     .main-layout {

--- a/script.js
+++ b/script.js
@@ -1,5 +1,70 @@
 let apiKey = '';
 let temperature = 0.7; // Default temperature value
+let outputMode = 'confidence'; // 'confidence' or 'markdown'
+
+// Simple markdown parser
+function parseMarkdown(text) {
+    // Escape HTML first
+    text = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    
+    // Headers
+    text = text.replace(/^### (.*$)/gm, '<h3>$1</h3>');
+    text = text.replace(/^## (.*$)/gm, '<h2>$1</h2>');
+    text = text.replace(/^# (.*$)/gm, '<h1>$1</h1>');
+    
+    // Bold and italic
+    text = text.replace(/\*\*\*([^*]+)\*\*\*/g, '<strong><em>$1</em></strong>');
+    text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    text = text.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+    text = text.replace(/___([^_]+)___/g, '<strong><em>$1</em></strong>');
+    text = text.replace(/__([^_]+)__/g, '<strong>$1</strong>');
+    text = text.replace(/_([^_]+)_/g, '<em>$1</em>');
+    
+    // Code blocks
+    text = text.replace(/```([^`]+)```/g, '<pre><code>$1</code></pre>');
+    text = text.replace(/`([^`]+)`/g, '<code>$1</code>');
+    
+    // Links
+    text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>');
+    
+    // Lists
+    text = text.replace(/^\* (.+$)/gm, '<li>$1</li>');
+    text = text.replace(/^- (.+$)/gm, '<li>$1</li>');
+    text = text.replace(/^(\d+)\. (.+$)/gm, '<li>$2</li>');
+    
+    // Wrap consecutive list items in ul/ol tags
+    text = text.replace(/(<li>.*<\/li>)/g, function(match) {
+        return '<ul>' + match + '</ul>';
+    });
+    
+    // Fix multiple consecutive ul tags
+    text = text.replace(/<\/ul>\s*<ul>/g, '');
+    
+    // Blockquotes
+    text = text.replace(/^> (.+$)/gm, '<blockquote>$1</blockquote>');
+    
+    // Line breaks
+    text = text.replace(/\n\n/g, '</p><p>');
+    text = text.replace(/\n/g, '<br>');
+    
+    // Wrap in paragraphs
+    if (text && !text.startsWith('<')) {
+        text = '<p>' + text + '</p>';
+    }
+    
+    // Clean up empty paragraphs
+    text = text.replace(/<p><\/p>/g, '');
+    text = text.replace(/<p>(<h[1-6]>)/g, '$1');
+    text = text.replace(/(<\/h[1-6]>)<\/p>/g, '$1');
+    text = text.replace(/<p>(<blockquote>)/g, '$1');
+    text = text.replace(/(<\/blockquote>)<\/p>/g, '$1');
+    text = text.replace(/<p>(<ul>)/g, '$1');
+    text = text.replace(/(<\/ul>)<\/p>/g, '$1');
+    text = text.replace(/<p>(<pre>)/g, '$1');
+    text = text.replace(/(<\/pre>)<\/p>/g, '$1');
+    
+    return text;
+}
 
 // Try to load API key from local environment on page load
 async function loadLocalConfig() {
@@ -201,8 +266,14 @@ async function sendMessage() {
         // Remove loading message
         loadingMessage.remove();
         
-        // Add AI response with confidence highlighting and token usage
-        const processedResponse = processResponseWithLogprobs(aiResponse, logprobs);
+        // Process response based on current output mode
+        let processedResponse;
+        if (outputMode === 'markdown') {
+            processedResponse = `<div class="markdown-content">${parseMarkdown(aiResponse)}</div>`;
+        } else {
+            processedResponse = processResponseWithLogprobs(aiResponse, logprobs);
+        }
+        
         addMessage(processedResponse, false, false, tokenUsage);
         
     } catch (error) {
@@ -351,6 +422,16 @@ document.addEventListener('DOMContentLoaded', function() {
             // Convert slider value (0-20) to temperature (0.0-2.0)
             temperature = parseFloat(this.value) / 10;
             temperatureValue.textContent = temperature.toFixed(1);
+        });
+    }
+    
+    // Output mode toggle functionality
+    const outputModeToggle = document.getElementById('outputModeToggle');
+    
+    if (outputModeToggle) {
+        outputModeToggle.addEventListener('change', function() {
+            outputMode = this.checked ? 'markdown' : 'confidence';
+            console.log('Output mode changed to:', outputMode);
         });
     }
 });

--- a/script.js
+++ b/script.js
@@ -66,36 +66,68 @@ function parseMarkdown(text) {
     return text;
 }
 
-// Try to load API key from local environment on page load
-async function loadLocalConfig() {
-    try {
-        const response = await fetch('/api/config');
-        const config = await response.json();
+// Initialize the application
+function initializeApp() {
+    // Check if we're in production mode
+    if (window.AI_DEMO_CONFIG && window.AI_DEMO_CONFIG.isProduction) {
+        isProduction = true;
+        apiKey = window.AI_DEMO_CONFIG.apiKey;
         
-        if (config.success && config.apiKey) {
-            apiKey = config.apiKey;
-            document.getElementById('apiKeyContainer').style.display = 'none';
-            document.getElementById('chatContainer').style.display = 'flex';
-            document.getElementById('messageInput').focus();
-            
-            // Show a success message
-            const messagesContainer = document.getElementById('messages');
-            const welcomeMessage = document.createElement('div');
-            welcomeMessage.className = 'system-message';
-            welcomeMessage.innerHTML = `
-                <div class="system-content">
-                    ✅ API key loaded from environment variables.<br>
-                    Ready to chat! Try asking something to see confidence levels.
-                </div>
-            `;
-            messagesContainer.appendChild(welcomeMessage);
-            
-            return true;
+        if (!apiKey || apiKey === '%API_KEY%' || apiKey === 'DEVELOPMENT_MODE_NO_KEY') {
+            if (apiKey === 'DEVELOPMENT_MODE_NO_KEY') {
+                // Local development mode - show API key input
+                showLocalDevMode();
+            } else {
+                showError('Production environment not properly configured. Please contact the administrator.');
+            }
+            return;
         }
-    } catch (error) {
-        console.log('Local config not available, falling back to manual input');
+        
+        // Hide API key container and show chat in production
+        const apiKeyContainer = document.getElementById('apiKeyContainer');
+        if (apiKeyContainer) {
+            apiKeyContainer.style.display = 'none';
+        }
+        
+        const chatContainer = document.getElementById('chatContainer');
+        if (chatContainer) {
+            chatContainer.style.display = 'flex';
+        }
+        
+        document.getElementById('messageInput').focus();
+    } else {
+        // Local development mode - show API key input
+        const apiKeyContainer = document.getElementById('apiKeyContainer');
+        if (apiKeyContainer) {
+            apiKeyContainer.style.display = 'block';
+        }
+        
+        const chatContainer = document.getElementById('chatContainer');
+        if (chatContainer) {
+            chatContainer.style.display = 'none';
+        }
     }
-    return false;
+}
+
+function showLocalDevMode() {
+    // Show API key input for local development
+    const apiKeyContainer = document.getElementById('apiKeyContainer');
+    if (apiKeyContainer) {
+        apiKeyContainer.style.display = 'block';
+    }
+    
+    const chatContainer = document.getElementById('chatContainer');
+    if (chatContainer) {
+        chatContainer.style.display = 'none';
+    }
+    
+    // Update production notice to show development mode
+    const productionNotice = document.querySelector('.production-notice p');
+    if (productionNotice) {
+        productionNotice.innerHTML = '🔧 Development Mode: Please enter your API key to continue.';
+        productionNotice.parentElement.style.backgroundColor = '#fff3cd';
+        productionNotice.parentElement.style.borderColor = '#ffeaa7';
+    }
 }
 
 function setApiKey() {
@@ -311,14 +343,8 @@ document.getElementById('apiKeyInput').addEventListener('keydown', function(e) {
 
 // Load config on page load
 document.addEventListener('DOMContentLoaded', async function() {
-    // Try to load local config first
-    const configLoaded = await loadLocalConfig();
-    
-    if (!configLoaded) {
-        // Show manual input if config couldn't be loaded
-        document.getElementById('apiKeyContainer').style.display = 'block';
-        document.getElementById('chatContainer').style.display = 'none';
-    }
+    // Initialize the application
+    initializeApp();
 });
 
 // Dynamic tooltip positioning

--- a/styles.css
+++ b/styles.css
@@ -475,3 +475,192 @@ body {
     font-weight: 600;
     color: #007aff;
 }
+
+/* Output Mode Toggle Styles */
+.output-mode-control {
+    padding: 1rem;
+    background: #f8f9fa;
+    border-bottom: 1px solid #e5e5e7;
+}
+
+.output-mode-label {
+    text-align: center;
+    margin-bottom: 0.75rem;
+    font-size: 0.9rem;
+    color: #333;
+    font-weight: 500;
+}
+
+.output-mode-toggle {
+    display: flex;
+    justify-content: center;
+}
+
+.toggle-container {
+    position: relative;
+    display: inline-block;
+}
+
+.toggle-checkbox {
+    opacity: 0;
+    position: absolute;
+    width: 0;
+    height: 0;
+}
+
+.toggle-label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+    position: relative;
+    padding: 0 4rem;
+}
+
+.toggle-slider {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    width: 3rem;
+    height: 1.5rem;
+    background-color: #007aff;
+    border-radius: 0.75rem;
+    transition: background-color 0.3s;
+}
+
+.toggle-slider::before {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 1.25rem;
+    height: 1.25rem;
+    background-color: white;
+    border-radius: 50%;
+    transition: transform 0.3s;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.toggle-checkbox:checked + .toggle-label .toggle-slider {
+    background-color: #10a37f;
+}
+
+.toggle-checkbox:checked + .toggle-label .toggle-slider::before {
+    transform: translateX(1.5rem);
+}
+
+.toggle-text-left,
+.toggle-text-right {
+    position: absolute;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: #666;
+    transition: color 0.3s;
+}
+
+.toggle-text-left {
+    left: 0;
+}
+
+.toggle-text-right {
+    right: 0;
+}
+
+.toggle-checkbox:not(:checked) + .toggle-label .toggle-text-left {
+    color: #007aff;
+    font-weight: 600;
+}
+
+.toggle-checkbox:checked + .toggle-label .toggle-text-right {
+    color: #10a37f;
+    font-weight: 600;
+}
+
+/* Markdown Styling */
+.markdown-content {
+    line-height: 1.6;
+    color: #1a1a1a;
+}
+
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
+.markdown-content h6 {
+    margin: 1rem 0 0.5rem 0;
+    font-weight: 600;
+    color: #1a1a1a;
+}
+
+.markdown-content h1 { font-size: 1.5rem; }
+.markdown-content h2 { font-size: 1.3rem; }
+.markdown-content h3 { font-size: 1.1rem; }
+
+.markdown-content p {
+    margin: 0.5rem 0;
+}
+
+.markdown-content strong {
+    font-weight: 600;
+}
+
+.markdown-content em {
+    font-style: italic;
+}
+
+.markdown-content code {
+    background: #f3f4f6;
+    padding: 0.125rem 0.25rem;
+    border-radius: 0.25rem;
+    font-family: 'SFMono-Regular', 'Monaco', 'Consolas', monospace;
+    font-size: 0.9em;
+    color: #d63384;
+}
+
+.markdown-content pre {
+    background: #f8f9fa;
+    border: 1px solid #e9ecef;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    margin: 1rem 0;
+    overflow-x: auto;
+    font-family: 'SFMono-Regular', 'Monaco', 'Consolas', monospace;
+    font-size: 0.875rem;
+    line-height: 1.4;
+}
+
+.markdown-content pre code {
+    background: none;
+    padding: 0;
+    border-radius: 0;
+    color: inherit;
+}
+
+.markdown-content ul,
+.markdown-content ol {
+    margin: 0.5rem 0;
+    padding-left: 1.5rem;
+}
+
+.markdown-content li {
+    margin: 0.25rem 0;
+}
+
+.markdown-content blockquote {
+    border-left: 4px solid #007aff;
+    margin: 1rem 0;
+    padding-left: 1rem;
+    color: #6b7280;
+    font-style: italic;
+}
+
+.markdown-content a {
+    color: #007aff;
+    text-decoration: none;
+}
+
+.markdown-content a:hover {
+    text-decoration: underline;
+}

--- a/styles.css
+++ b/styles.css
@@ -498,7 +498,10 @@ body {
 
 .toggle-container {
     position: relative;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    gap: 1rem;
+    min-width: 200px;
 }
 
 .toggle-checkbox {
@@ -511,10 +514,11 @@ body {
 .toggle-label {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     cursor: pointer;
     user-select: none;
     position: relative;
-    padding: 0 4rem;
+    width: 100%;
 }
 
 .toggle-slider {
@@ -527,6 +531,7 @@ body {
     background-color: #007aff;
     border-radius: 0.75rem;
     transition: background-color 0.3s;
+    z-index: 1;
 }
 
 .toggle-slider::before {
@@ -552,19 +557,12 @@ body {
 
 .toggle-text-left,
 .toggle-text-right {
-    position: absolute;
     font-size: 0.8rem;
     font-weight: 500;
     color: #666;
     transition: color 0.3s;
-}
-
-.toggle-text-left {
-    left: 0;
-}
-
-.toggle-text-right {
-    right: 0;
+    z-index: 2;
+    position: relative;
 }
 
 .toggle-checkbox:not(:checked) + .toggle-label .toggle-text-left {


### PR DESCRIPTION
This pull request introduces significant enhancements to the `AI Confidence Demonstration Tool`, focusing on improving local development workflows, adding a markdown rendering feature, and implementing a toggle for output modes. The most impactful changes include better handling of local development environments, a new markdown parser, and updates to the UI for toggling between "Confidence" and "Markdown" output modes.

### Enhancements for Local Development:
* In `build.sh`, improved handling of the `OPENROUTER_API_KEY` environment variable by introducing a placeholder for local development mode (`DEVELOPMENT_MODE_NO_KEY`) and providing fallback values for build metadata. [[1]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L18-R29) [[2]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L64-R88)
* Added a `showLocalDevMode` function in `public/script.js` to display an API key input and update the UI for development mode.

### Markdown Rendering Feature:
* Implemented a `parseMarkdown` function in `public/script.js` to convert markdown syntax into HTML, supporting headers, formatting, code blocks, links, lists, and blockquotes.
* Updated the `sendMessage` function in `public/script.js` to process AI responses as markdown when the output mode is set to "Markdown."

### Output Mode Toggle:
* Added a UI toggle in `public/index.html` allowing users to switch between "Confidence" and "Markdown" output modes.
* Integrated functionality in `public/script.js` to handle changes in the output mode toggle and dynamically update the mode.
* Styled the output mode toggle and markdown content in `public/styles.css` for improved user experience.