### PR TITLE
Refactor deployment workflows: remove Cloudflare authentication step …

### DIFF
--- a/.github/workflows/deploy-env-vars.yml
+++ b/.github/workflows/deploy-env-vars.yml
@@ -2,9 +2,6 @@ name: Deploy Environment Variables to Cloudflare
 
 on:
   workflow_dispatch: # Manual trigger
-  push:
-    branches: [main]
-    paths: ['.github/workflows/deploy-env-vars.yml'] # Only run when this file changes
 
 jobs:
   deploy-env-vars:
@@ -22,21 +19,23 @@ jobs:
     - name: Install Wrangler
       run: npm install -g wrangler
 
-    - name: Authenticate with Cloudflare
-      run: |
-        echo "${{ secrets.CLOUDFLARE_API_TOKEN }}" | wrangler auth login --api-token
-
     - name: Set OpenRouter API Key
       run: |
-        wrangler pages secret put OPENROUTER_API_KEY_V2 \
+        echo "${{ secrets.OPENROUTER_API_KEY_V2 }}" | wrangler pages secret put OPENROUTER_API_KEY_V2 \
           --project-name=${{ secrets.CLOUDFLARE_PROJECT_NAME }} \
-          --env=production <<< "${{ secrets.OPENROUTER_API_KEY_V2 }}"
+          --env=production
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
     - name: Set OpenAI API Key
       run: |
-        wrangler pages secret put OPENAI_EMBEDDINGS_API_KEY \
+        echo "${{ secrets.OPENAI_EMBEDDINGS_API_KEY }}" | wrangler pages secret put OPENAI_EMBEDDINGS_API_KEY \
           --project-name=${{ secrets.CLOUDFLARE_PROJECT_NAME }} \
-          --env=production <<< "${{ secrets.OPENAI_EMBEDDINGS_API_KEY }}"
+          --env=production
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
     - name: Verify deployment
       run: |

--- a/.github/workflows/deploy-to-cloudflare.yml
+++ b/.github/workflows/deploy-to-cloudflare.yml
@@ -40,9 +40,6 @@ jobs:
     - name: Configure Environment Variables (Production only)
       if: github.ref == 'refs/heads/main'
       run: |
-        # Authenticate with Cloudflare
-        echo "${{ secrets.CLOUDFLARE_API_TOKEN }}" | wrangler auth login --api-token
-        
         # Deploy environment variables using Wrangler
         echo "🔐 Setting up secure environment variables..."
         
@@ -53,6 +50,9 @@ jobs:
           --project-name=${{ secrets.CLOUDFLARE_PROJECT_NAME }} --env=production
           
         echo "✅ Environment variables configured successfully!"
+      env:
+        CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
     - name: Deployment Summary
       run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for deploying environment variables to Cloudflare. The main improvements involve simplifying authentication, securely passing secrets, and cleaning up redundant triggers.

**Workflow authentication and secret management:**

* Removed explicit `wrangler auth login` steps from both `.github/workflows/deploy-env-vars.yml` and `.github/workflows/deploy-to-cloudflare.yml`, relying instead on environment variables for authentication. [[1]](diffhunk://#diff-7a082d80766220240c7cd52a5ef9481543819a6674e91643331ecfbb0aa38a8aL25-R38) [[2]](diffhunk://#diff-b890f045dad22a3d4ad74eb0ecfbe5865e6345741cf67b17f6fcf25a9df523f4L43-L45)
* Updated secret setting steps to pipe secrets directly into `wrangler pages secret put` using `echo`, and set necessary Cloudflare credentials (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) via the `env` field for each step. [[1]](diffhunk://#diff-7a082d80766220240c7cd52a5ef9481543819a6674e91643331ecfbb0aa38a8aL25-R38) [[2]](diffhunk://#diff-b890f045dad22a3d4ad74eb0ecfbe5865e6345741cf67b17f6fcf25a9df523f4R53-R55)

**Workflow trigger improvements:**

* Removed the `push` trigger from `.github/workflows/deploy-env-vars.yml` so the workflow now only runs on manual dispatch, preventing unnecessary runs on file changes.